### PR TITLE
Fix double-counted batch loss in LSTM training

### DIFF
--- a/core.py
+++ b/core.py
@@ -686,8 +686,6 @@ def train_LSTM(model, train_loader, device, lr=0.01, epochs=1000, patience=50, m
             scaler.step(optimizer)
             scaler.update()
             epoch_loss += loss.item() * X_batch.size(0)
-            
-            epoch_loss += loss.item() * X_batch.size(0)
 
         # Average loss
         epoch_loss /= len(train_loader.dataset)


### PR DESCRIPTION
## Summary
- avoid counting each batch's loss twice during LSTM training

## Testing
- `python -m py_compile core.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5e91d2588327a733d31feb8a963b