### PR TITLE
Document reward state and update position column names

### DIFF
--- a/core.py
+++ b/core.py
@@ -235,9 +235,10 @@ def align_brain_and_behavior(events: pd.DataFrame, spike_rates: np.ndarray, unit
     events : pd.DataFrame
         Behavioral tracking data containing columns:
         - 'timestamps_ms': Timestamps in milliseconds
-        - 'centroid_x', 'centroid_y': Position coordinates
+        - 'position_x', 'position_y': Position coordinates
         - 'velocity_x', 'velocity_y': Velocity components
         - 'speed': Overall movement speed
+        - 'reward_state': Reward state indicator
     
     spike_rates : np.ndarray
         Matrix of spike rates with shape (n_units, n_time_bins).


### PR DESCRIPTION
## Summary
- replace outdated 'centroid_x/centroid_y' with 'position_x/position_y' in the `align_brain_and_behavior` docstring
- document `reward_state` column used in neural-behavior alignment

## Testing
- `python -m py_compile core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6044d4548327ae9ca5a938563c88